### PR TITLE
remove cubedsphere dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please install the following packages beforehand:
 **general:**
 xarray, netcdf4
 
-**exPERT/MITgcm:**
+**exPERT/MITgcm - raw files:**
 xmitgcm, xgcm, f90nml,
 [cubedsphere](https://cubedsphere.readthedocs.io/en/latest/index.html)
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -4,8 +4,6 @@ There are several ways to install the package.
 We recommend using anaconda.
 ``gcm_toolkit`` has been tested to work on linux and mac.
 
-.. note::
-    Using Windows is not recommended and will not work in combination with MITgcm raw data.
 
 Using anaconda
 ----------------
@@ -16,13 +14,16 @@ Create an anaconda environment.
     conda create -n 'GCM' -y
     conda activate GCM
 
-Install a few dependencies (optional include the following packages: ``jupyterlab`` and ``cartopy``.)
+Install a few optional packages
 
 .. code-block:: bash
 
     conda install -c conda-forge cubedsphere jupyterlab cartopy -y
     pip install git+https://github.com/MITgcm/xmitgcm.git
 
+.. note::
+    The ``cubedsphere`` package has many dependencies and it is only needed for reading in and converting raw MITgcm files.
+    It might not work in several environments.
 
 Install ``gcm_toolkit``.
 

--- a/gcm_toolkit/core/const.py
+++ b/gcm_toolkit/core/const.py
@@ -4,65 +4,60 @@
 ==============================================================
 Consistent namings of variables
 
-These variable names are currently synced with the naming scheme
+These variable names are currently in sync with the naming scheme
 from the cubedsphere package.
 The advantage of that is that we do not need to worry about
 variable naming inconsistancies with exorad data.
-Warning: If at some points other standards are used here,
-    we would need to make sure to rename variables
-    in the readin routines of exorad data!
 ==============================================================
 """
-import cubedsphere.const as cc
-
 VARNAMES = dict(
-    FACEDIM=cc.FACEDIM,  # index of the facedimension
+    FACEDIM="face",  # index of the facedimension
     iter="iter",  # iter index
-    time=cc.time,
-    j=cc.j,  # Y index
-    i=cc.i,  # X index
-    i_g=cc.i_g,  # X index at interface
-    j_g=cc.j_g,  # Y index at interface
-    k=cc.k,  # Z index
-    k_l=cc.k_l,  # upper Z interface
-    k_p1=cc.k_p1,  # outer Z interface
-    k_u=cc.k_u,  # lower Z interface
-    Z=cc.Z,  # Z index
-    Z_l=cc.Z_l,  # lower Z interface
-    Z_p1=cc.Z_p1,  # outer Z interface
-    Z_u=cc.Z_u,  # upper Z interface
-    Z_geo=cc.Z_geo,  # geometrical height
-    T=cc.T,  # Temperature
+    time="time",
+    j="j",  # Y index
+    i="i",  # X index
+    i_g="i_g",  # X index at interface
+    j_g="j_g",  # Y index at interface
+    k="k",  # Z index
+    k_l="k_l",  # upper Z interface
+    k_p1="k_p1",  # outer Z interface
+    k_u="k_u",  # lower Z interface
+    Z="Z",  # Z index
+    Z_l="Z_l",  # lower Z interface
+    Z_p1="Z_p1",  # outer Z interface
+    Z_u="Z_u",  # upper Z interface
+    Z_geo="Z_geo",  # geometrical height
+    T="T",  # Temperature
     U="U",
     V="V",
-    W=cc.W,
-    Ttave=cc.Ttave,  # Temperature averaged
-    wVeltave=cc.wVeltave,  # vertical velocity timeaveraged
-    drW=cc.drW,
-    drS=cc.drS,
-    HFacW=cc.HFacW,
-    HFacS=cc.HFacS,
-    HFacC=cc.HFacC,
-    drF=cc.drF,
-    drC=cc.drC,
-    dxC=cc.dxC,
-    dxG=cc.dxG,
-    dyC=cc.dyC,
-    dyG=cc.dyG,
-    rA=cc.rA,
-    rAz=cc.rAz,
-    rAs=cc.rAs,
-    rAw=cc.rAw,
-    lon=cc.lon,
-    lon_b=cc.lon_b,
-    lat_b=cc.lat_b,
-    lat=cc.lat,
-    AngleCS=cc.AngleCS,
-    AngleSN=cc.AngleSN,
-    dxF=cc.dxF,
-    dyU=cc.dyU,
-    dxV=cc.dxV,
-    dyF=cc.dyF,
+    W="W",
+    Ttave="Ttave",  # Temperature averaged
+    wVeltave="wVeltave",  # vertical velocity timeaveraged
+    drW="drW",
+    drS="drS",
+    HFacW="HFacW",
+    HFacS="HFacS",
+    HFacC="HFacC",
+    drF="drF",
+    drC="drC",
+    dxC="dxC",
+    dxG="dxG",
+    dyC="dyC",
+    dyG="dyG",
+    rA="rA",
+    rAz="rAz",
+    rAs="rAs",
+    rAw="rAw",
+    lon="lon",
+    lon_b="lon_b",
+    lat_b="lat_b",
+    lat="lat",
+    AngleCS="AngleCS",
+    AngleSN="AngleSN",
+    dxF="dxF",
+    dyU="dyU",
+    dxV="dxV",
+    dyF="dyF",
     P_rot="P_rot",
     P_orb="P_orb",
     g="g",

--- a/gcm_toolkit/exorad/utils.py
+++ b/gcm_toolkit/exorad/utils.py
@@ -3,12 +3,8 @@ utils to work with cubedsphere
 """
 import os
 
-import cubedsphere as cs
-import cubedsphere.const as c
 import numpy as np
-import xgcm
 from f90nml import Parser
-from xgcm.autogenerate import generate_grid_ds
 
 
 class MITgcmDataParser(Parser):
@@ -81,6 +77,9 @@ def convert_winds_and_t(dsi, temp_dim, w_dim):
     ds: Dataset
         dataset with converted dimension
     """
+    import cubedsphere as cs
+    import cubedsphere.const as c
+
     kappa = dsi.attrs["R"] / dsi.attrs["cp"]
     dsi[temp_dim] = dsi[temp_dim] * (dsi[c.Z] / dsi.attrs["p_ref"]) ** kappa
 
@@ -128,6 +127,8 @@ def exorad_postprocessing(dsi, outdir=None, datafile=None):
     ds:
         Dataset to be returned
     """
+    import cubedsphere.const as c
+
     stri = "please specify a datafile or a folder where we can find a datafile"
     assert outdir is not None or datafile is not None, stri
 
@@ -190,6 +191,9 @@ def add_distances(dsi, radius):
     ds  : xarray.DataArray distance inferred from dlon
     dy  : xarray.DataArray distance inferred from dlat
     """
+    import cubedsphere.const as c
+    import xgcm
+    from xgcm.autogenerate import generate_grid_ds
 
     def dll_dist(dlon, dlat, lon, lat, radius):
         """Converts lat/lon differentials into distances in meters


### PR DESCRIPTION
This PR refactors the import statements of `cubedsphere`, which enables to load it only when its really needed.

This means that people can now finally install `gcm_toolkit` without the need of `cubedsphere` 👯‍♂️ 🥳 
... At least when they do not intend to read raw MITgcm data.

Closes #33  